### PR TITLE
Added docker-cli and aws-cli to jenkins-git image

### DIFF
--- a/jenkins/git/Dockerfile
+++ b/jenkins/git/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.11
 
 ARG DUMB_INIT_VERSION=1.2.2
 ARG ARGOCD_VERSION=v1.5.2
+ARG AWSCLI_VERSION=1.18.56
 ARG user=jenkins
 ARG group=docker
 ARG uid=1004
@@ -36,12 +37,18 @@ RUN apk --update add --no-cache \
     openssl \
     bash \
     git \
+    docker-cli \
+    python3 \
+    py3-pip \
+    groff \
+    less \
+    mailcap \
     openssh-client \
   && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 \
   && wget -O /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64 \
   && chmod +x /usr/bin/dumb-init /usr/local/bin/argocd \
-  && apk del wget
-
+  && pip3 install --upgrade awscli==${AWSCLI_VERSION} \
+  && apk del wget py3-pip
 
 USER ${user}
 

--- a/jenkins/git/README.md
+++ b/jenkins/git/README.md
@@ -1,9 +1,9 @@
 # Jenkins git
 
-A git client jenkins image very similar to marfeel/jenkins-openssh but
+A git client jenkins image similar to marfeel/jenkins-openssh but
 
 - based on alpine 3:11
 - adds yq from an alpine-based build (and so to be safe, best executed inside alpine)
-- has a few less tools (no pssh and no rsync or make)
-
-Eventually this image could be used to replace marfeel/jenkins-openssh if the missing tools are not used
+- replaces some  pipeline tools not used with docker builds (no pssh and no rsync or make for instance) with those that do:
+  - docker-cli
+  - aws-cli

--- a/jenkins/git/ssh_config
+++ b/jenkins/git/ssh_config
@@ -8,5 +8,4 @@ Host *
 
 Host github.com
     User git
-    IdentityFile ~/.ssh/github_rsa
     StrictHostKeyChecking yes


### PR DESCRIPTION
- This will allow us to use this image to build docker
  image in Jenkins and push to ECR directly from it