### PR TITLE
fix: Do not load module that prevents the process to start [SYS-53464]

### DIFF
--- a/rsyslog/Dockerfile
+++ b/rsyslog/Dockerfile
@@ -20,6 +20,12 @@ RUN : \
     && rm -rf /var/lib/apt/lists/* \
     && :
 
-COPY Dockerfile /Dockerfile
+COPY rsyslog.conf /etc/rsyslog.conf
+COPY Dockerfile   /Dockerfile
 
-CMD ["/usr/sbin/rsyslogd", "-n", "-f", "/etc/rsyslog.conf"]
+VOLUME [ "/etc/rsyslog.d" ]
+
+EXPOSE 514/tcp
+EXPOSE 517/udp
+
+CMD [ "/usr/sbin/rsyslogd", "-n", "-f", "/etc/rsyslog.conf" ]

--- a/rsyslog/rsyslog.conf
+++ b/rsyslog/rsyslog.conf
@@ -1,5 +1,4 @@
 $ModLoad imuxsock # provides support for local system logging
-$ModLoad imklog   # provides kernel logging support (previously done by rklogd)
 module(load="omprog")
 module(load="imudp" threads="8")
 input(type="imudp" port="517")

--- a/rsyslog/rsyslog.conf
+++ b/rsyslog/rsyslog.conf
@@ -1,0 +1,29 @@
+$ModLoad imuxsock # provides support for local system logging
+$ModLoad imklog   # provides kernel logging support (previously done by rklogd)
+module(load="omprog")
+module(load="imudp" threads="8")
+input(type="imudp" port="517")
+
+main_queue (
+        queue.type="fixedArray"
+        queue.size="250000"
+        queue.dequeueBatchSize="4096"
+        queue.workerThreads="4"
+        queue.workerThreadMinimumMessages="60000"
+        queue.discardSeverity="6"
+        queue.timeoutEnqueue="0"
+)
+
+$MaxOpenFiles 40000
+$RepeatedMsgReduction off
+$EscapeControlCharactersOnReceive off
+$MaxMessageSize 124k
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+$WorkDirectory /var/spool/rsyslog
+$IncludeConfig /etc/rsyslog.d/*.conf


### PR DESCRIPTION
```text
root@9c0fcef1f245:/# rsyslogd -f /etc/rsyslog.conf
rsyslogd: imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.
rsyslogd: activation of module imklog failed [v8.2304.0 try https://www.rsyslog.com/e/2145 ]
root@9c0fcef1f245:/# stat /proc/kmsg
  File: /proc/kmsg
  Size: 0               Blocks: 0          IO Block: 1024   regular empty file
Device: 69h/105d        Inode: 4026532047  Links: 1
Access: (0400/-r--------)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2023-06-16 07:21:01.454834004 +0000
Modify: 2023-06-16 07:21:01.454834004 +0000
Change: 2023-06-16 07:21:01.454834004 +0000
 Birth: -
root@9c0fcef1f245:/# cat /etc/rsyslog.conf | grep Priv
$PrivDropToUser syslog
$PrivDropToGroup syslog
```