### PR TITLE
chore: Install pgvector required for discourse-ai [SYS-71623]

### DIFF
--- a/discourse-postgresql/Dockerfile
+++ b/discourse-postgresql/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/bitnami/postgresql:16.1.0-debian-11-r18
+
+USER root
+
+RUN install_packages git build-essential && \
+    cd /tmp && \
+    git clone --branch v0.4.1 https://github.com/pgvector/pgvector.git && \
+    cd pgvector && \
+    export PG_CONFIG=/opt/bitnami/postgresql/bin/pg_config && \
+    make && \
+    make install
+
+USER 1001


### PR DESCRIPTION
Install this extension is required for restore the database backup.